### PR TITLE
Fix health history permission, sync interval persistence, and HRV collection

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -582,10 +582,14 @@ export default Sentry.wrap(function App() {
             defaultValue={(taskDelay / (1000 * 60 * 60)).toString()}
             onChangeText={text => {
               const hours = Number(text);
-              taskDelay = hours * 60 * 60 * 1000; 
+              // Clearing the field mid-edit yields Number('') === 0, which
+              // registers a 0ms loop.
+              if (!Number.isFinite(hours) || hours <= 0) return;
+              taskDelay = hours * 60 * 60 * 1000;
               setPlain('taskDelay', String(taskDelay));
               ReactNativeForegroundService.update_task(() => sync(), {
                 delay: taskDelay,
+                taskId: 'hcgateway_sync',
               })
               Toast.show({
                 type: 'success',

--- a/app/App.js
+++ b/app/App.js
@@ -160,6 +160,7 @@ const askForPermissions = async () => {
     { accessType: 'read', recordType: 'ElevationGained' },
     { accessType: 'read', recordType: 'FloorsClimbed' },
     { accessType: 'read', recordType: 'HeartRate' },
+    { accessType: 'read', recordType: 'HeartRateVariabilityRmssd' },
     { accessType: 'read', recordType: 'Height' },
     { accessType: 'read', recordType: 'Hydration' },
     { accessType: 'read', recordType: 'LeanBodyMass' },
@@ -294,7 +295,7 @@ const sync = async (customStartTime, customEndTime) => {
     lastSync = currentTime;
   }
 
-  let recordTypes = ["ActiveCaloriesBurned", "BasalBodyTemperature", "BloodGlucose", "BloodPressure", "BasalMetabolicRate", "BodyFat", "BodyTemperature", "BoneMass", "CyclingPedalingCadence", "CervicalMucus", "ExerciseSession", "Distance", "ElevationGained", "FloorsClimbed", "HeartRate", "Height", "Hydration", "LeanBodyMass", "MenstruationFlow", "MenstruationPeriod", "Nutrition", "OvulationTest", "OxygenSaturation", "Power", "RespiratoryRate", "RestingHeartRate", "SleepSession", "Speed", "Steps", "StepsCadence", "TotalCaloriesBurned", "Vo2Max", "Weight", "WheelchairPushes"]; 
+  let recordTypes = ["ActiveCaloriesBurned", "BasalBodyTemperature", "BloodGlucose", "BloodPressure", "BasalMetabolicRate", "BodyFat", "BodyTemperature", "BoneMass", "CyclingPedalingCadence", "CervicalMucus", "ExerciseSession", "Distance", "ElevationGained", "FloorsClimbed", "HeartRate", "HeartRateVariabilityRmssd", "Height", "Hydration", "LeanBodyMass", "MenstruationFlow", "MenstruationPeriod", "Nutrition", "OvulationTest", "OxygenSaturation", "Power", "RespiratoryRate", "RestingHeartRate", "SleepSession", "Speed", "Steps", "StepsCadence", "TotalCaloriesBurned", "Vo2Max", "Weight", "WheelchairPushes"]; 
   
   for (let i = 0; i < recordTypes.length; i++) {
       let records;

--- a/app/App.js
+++ b/app/App.js
@@ -508,14 +508,14 @@ export default Sentry.wrap(function App() {
     });
 
     get('login')
-    .then(res => {
+    .then(async res => {
       if (res) {
         login = res;
-        get('taskDelay')
-        .then(res => {
-          if (res) taskDelay = Number(res);
-        })
-        
+        // Read the stored interval before registering the task; registering
+        // first pins it to the default forever.
+        const storedDelay = Number(await get('taskDelay'));
+        if (Number.isFinite(storedDelay) && storedDelay > 0) taskDelay = storedDelay;
+
         ReactNativeForegroundService.add_task(() => sync(), {
           delay: taskDelay,
           onLoop: true,

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-  <uses-permission android:name="android.permission.PERMISSION_READ_HEALTH_DATA_HISTORY"/>
+  <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY"/>
   <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED"/>
   <uses-permission android:name="android.permission.health.READ_BASAL_BODY_TEMPERATURE"/>
   <uses-permission android:name="android.permission.health.READ_BASAL_METABOLIC_RATE"/>


### PR DESCRIPTION
Four fixes found while running this app against a self-hosted server for a few days. Each is a separate commit so they can be taken independently.

---

**1. Health history permission string is invalid** (`e34eeaf`)

The manifest declares `android.permission.PERMISSION_READ_HEALTH_DATA_HISTORY`, which is not a real permission. `PERMISSION_READ_HEALTH_DATA_HISTORY` is the constant name in the Health Connect SDK; the manifest value is `android.permission.health.READ_HEALTH_DATA_HISTORY` — note every other health permission in the same file already uses the `health.` namespace.

This fails silently. The permission is never granted, reads are capped at 30 days, and nothing in the UI or logs indicates it. I spent a day assuming my server was dropping records before finding this.

**2. Sync interval reverts to 2 hours on every app start** (`5b7209b`)

`get('taskDelay')` returns a Promise, but `add_task` is called outside the `.then`, so `delay` always reads the initial `7200000`. A user-configured interval works until the app restarts, then silently reverts.

**3. Clearing the interval field schedules a 0ms loop** (`06004fd`)

`onChangeText` fires per keystroke, so clearing the field to retype it passes `Number('') === 0`. `update_task` was also missing `taskId`, so the runaway task can't be replaced. I measured 18 POSTs in 17 seconds; the only recovery was force-stopping the app.

Interestingly, bug 2 acts as a safety net here — since `add_task` always re-registers with the default, a persisted `taskDelay` of `0` doesn't survive a restart. Fixing 2 without 3 would remove that accident, so they belong together.

**4. `HeartRateVariabilityRmssd` is never collected** (`ec313f8`)

The manifest already declares `READ_HEART_RATE_VARIABILITY`, but the record type is missing from both `requestPermission()` and `recordTypes`, so the permission is never requested and the data is never read.

Caveat: Samsung Health does not write HRV to Health Connect ([many reports](https://us.community.samsung.com/t5/Galaxy-Watch/HRV-breathing-rate-and-resting-HR-won-t-write-to-the-health/td-p/3351258)), so Galaxy users will still see zero records — the watch computes HRV for its stress/energy score but keeps it in-app. Other sources do write it.

---

**Verification**

Built an APK from this branch and diffed it against the v2.2.1 release: same signing certificate (`fac61745…`) and package name, permission string corrected in the compiled manifest, `HeartRateVariabilityRmssd` present in the Hermes bundle (absent in v2.2.1). Installed over the existing app — the interval now survives a force-stop and restart.

Note that `.github/workflows/build.yml` doesn't currently run: it needs `EXPO_TOKEN` for `eas build --local` and uses `actions/upload-artifact@v2`, which is retired. I built with gradle directly against the prebuilt `app/android/`. Happy to open a separate PR for that if it's useful, but I left it out here to keep this to bug fixes.
